### PR TITLE
Fix testsuite out of sourcetree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     include:
         - python: 2.7
         - python: 3.4
+        - python: 3.5
         - python: pypy
 
 install:

--- a/dev_requirements26.txt
+++ b/dev_requirements26.txt
@@ -1,2 +1,3 @@
--r dev_requirements.txt
 unittest2
+stevedore<1.8
+-r dev_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py26,py27,py34,py35,pypy
 
 [testenv]
 deps= -rdev_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py26,py27,py33,py34,pypy
 
 [testenv]
 deps= -rdev_requirements.txt
-# To make sure we actually test the tarball and now the working directory
-changedir = .tox
+# To make sure we actually test the tarball and not the working directory
+changedir = {envtmpdir}
 commands=haas zipfile2
 
 [testenv:py26]

--- a/zipfile2/tests/test__zipfile.py
+++ b/zipfile2/tests/test__zipfile.py
@@ -224,20 +224,22 @@ class TestZipFile(unittest.TestCase):
         # Given
         zipfile = os.path.join(self.tempdir, "foo.zip")
         to = os.path.join(self.tempdir, "to")
+
         filename = os.path.relpath(__file__, os.getcwd())
+        arcname = os.path.basename(filename)
 
         # When
         with ZipFile(zipfile, "w") as zp:
-            zp.write(filename)
+            zp.write(filename, arcname)
             with self.assertRaises(ValueError):
-                zp.write(filename)
+                zp.write(filename, arcname)
 
         with ZipFile(zipfile) as zp:
             zp.extractall(to)
 
         # Then
         self.assertTrue(os.path.exists(zipfile))
-        self.assertTrue(os.path.exists(os.path.join(to, filename)))
+        self.assertTrue(os.path.exists(os.path.join(to, arcname)))
 
     def test_multiple_archives_writestr(self):
         # Given
@@ -264,8 +266,11 @@ class TestZipFile(unittest.TestCase):
         # Given
         zipfile = os.path.join(self.tempdir, "foo.zip")
         to = os.path.join(self.tempdir, "to")
+
         filename = os.path.relpath(__file__, os.getcwd())
-        arcname = filename
+        arcname = os.path.basename(filename)
+        with open(filename, "rb") as fp:
+            r_data = fp.read()
 
         # When
         with ZipFile(zipfile, "w") as zp:
@@ -278,7 +283,10 @@ class TestZipFile(unittest.TestCase):
 
         # Then
         self.assertTrue(os.path.exists(zipfile))
-        self.assertTrue(os.path.exists(os.path.join(to, filename)))
+        archive_path = os.path.join(to, arcname)
+        self.assertTrue(os.path.exists(archive_path))
+        with open(archive_path, "rb") as fp:
+            self.assertEqual(fp.read(), r_data)
 
     def test_multiple_archives_read(self):
         # Given


### PR DESCRIPTION
Fix #33 

Also update tox/travis for python 3.5, remove 3.3

@sjagoe